### PR TITLE
New CTFTime-compatible accepted-submissions.json

### DIFF
--- a/nizkctf/acceptedsubmissions.py
+++ b/nizkctf/acceptedsubmissions.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals, division, print_function,\
      absolute_import
 import os
 import time
-from .six import viewitems, text_type, to_bytes, to_unicode, PY2
+from .six import text_type
 from .subrepo import SubRepo
 from .serializable import SerializableDict
 
@@ -16,6 +16,8 @@ TIME_FORMAT = '%s'  # unix timestamp
 class AcceptedSubmissions(SerializableDict):
     def __init__(self):
         super(AcceptedSubmissions, self).__init__()
+        self.setdefault('tasks', [])
+        self.setdefault('standings', [])
 
     def path(self):
         return SubRepo.get_path(ACCEPTED_SUBMISSIONS_FILE)
@@ -47,25 +49,6 @@ class AcceptedSubmissions(SerializableDict):
         team['score'] += points
 
         self.save()
-
-    # TODO Unicode symbols in team names should be converted to unicode notation (\uXXXX).
-    #      reference: https://ctftime.org/json-scoreboard-feed
-    def _unserialize_inplace(self):
-        self.setdefault('tasks', [])
-        self.setdefault('standings', [])
-
-        for team in self['standings']:
-            #team['team'] = team['team'].encode('utf-8').decode('unicode_escape')
-            team['team'] = to_bytes(team['team']).decode('unicode_escape')
-
-    def _serialize(self):
-        from copy import deepcopy
-        serialized = deepcopy(self)
-
-        for team in serialized['standings']:
-            #team['team'] = team['team'].encode('unicode_escape').decode('utf-8')
-            team['team'] = to_unicode(team['team'].encode('unicode_escape'))
-        return serialized
 
 def current_time():
     return int(time.strftime(TIME_FORMAT))

--- a/nizkctf/cli/scoreboard.py
+++ b/nizkctf/cli/scoreboard.py
@@ -32,12 +32,13 @@ def rank():
 
     submissions = {}
     scores = {}
-    last_submission = {}
-    for subm_num, subm in enumerate(AcceptedSubmissions()):
-        team = subm['team']
-        score, _ = scores.get(team, (0, None))
-        scores[team] = (score + subm['points'], -subm_num)
-        submissions.setdefault(team, []).append(subm)
+    for team in AcceptedSubmissions()['standings']:
+        team_id = Team(name=team['team']).id
+        submissions[team_id] = [sub for sub in team['taskStats'].values()]
+        submissions[team_id] = sorted(submissions[team_id],
+                                      key=operator.itemgetter('time'))
+
+        scores[team_id] = (team['score'], -team['lastAccept'])
 
     scores = sorted(viewitems(scores), key=operator.itemgetter(1),
                     reverse=True)
@@ -109,6 +110,9 @@ def plot(ranking, submissions, top=3):
         submissions (dict): Dict [team] -> submission list.
         top (int): Number of teams to appear in chart.
     '''
+    if len(ranking) == 0:
+        return
+
     # generate temporary files with data points
     fnames = []
     for team, _ in ranking[0:top]:


### PR DESCRIPTION
This is a pull request to change the previous `accepted-submissions.json` format to the **CTFtime** compatible one, specified in [CTFtime - json scoreboard feed](https://ctftime.org/json-scoreboard-feed).

The major change is that now the team's name can't be encoded in base64, otherwise CTFtime wouldn't display the correct names. The docs says that:
 > Unicode symbols in team names should be converted to unicode notation (\uXXXX).

EDIT: The unicode notation is the default used by json library.

~Methods `_unserialize_inplace()` and `_serialize()` implement this logic.~ EDIT: Actually, they were not needed, check 812f3b8.

Everything was tested on both Python 2 and 3, including adding a new submission, printing the scoreboard and ploting the scoreboard. Everything works, ~except on the following situation:~

> ~The team name `u'ǘƐŢŀ normal áéà'` is stored as `'\\u01d8\\u0190\\u0162\\u0140 normal \\xe1\\xe9\\xe0'`. Why are the accents not being encoded as `\uXXXX`? Would CTFtime be able to read them?~ EDIT:  Check 812f3b8.